### PR TITLE
Add Redis caching layer for Prisma ORM

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { redis } from './redis';
 
 declare global {
   // allow global `var` declarations
@@ -6,11 +7,57 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-export const prisma =
-  global.prisma ||
-  new PrismaClient({
-    //log: ["error"],
-  });
+// Cache configuration
+const CACHE_TTL = 300; // 5 minutes
+const CACHE_ENABLED = process.env.REDIS_CACHE_ENABLED === 'true';
+const CACHE_MODELS = ['Team', 'User', 'Service']; // Models to cache
+
+// Create extended Prisma client
+const prismaInstance = global.prisma || new PrismaClient();
+
+// Add caching middleware
+prismaInstance.$use(async (params, next) => {
+  // Bypass cache if not enabled or not cacheable model
+  if (!CACHE_ENABLED || !CACHE_MODELS.includes(params.model)) {
+    return next(params);
+  }
+
+  // Generate cache key
+  const cacheKey = `prisma:${params.model}:${params.action}:${JSON.stringify(params.args)}`;
+
+  // Handle read operations (cache get)
+  if (['findUnique', 'findFirst', 'findMany', 'count'].includes(params.action)) {
+    try {
+      // Check cache
+      const cached = await redis.get(cacheKey);
+      if (cached) return JSON.parse(cached);
+      
+      // Execute query if not cached
+      const result = await next(params);
+      await redis.set(cacheKey, JSON.stringify(result), CACHE_TTL);
+      return result;
+    } catch (error) {
+      console.error('Cache read error:', error);
+      return next(params);
+    }
+  }
+  
+  // Handle write operations (cache invalidation)
+  if (['create', 'update', 'delete', 'upsert'].includes(params.action)) {
+    const result = await next(params);
+    
+    // Invalidate related cache
+    const pattern = `prisma:${params.model}:*`;
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) await redis.del(...keys);
+    
+    return result;
+  }
+  
+  return next(params);
+});
+
+export const prisma = prismaInstance;
 
 if (process.env.NODE_ENV !== 'production') {
   global.prisma = prisma;


### PR DESCRIPTION
## Description
Implements Redis caching middleware for Prisma ORM to improve database performance. Caches read operations and invalidates cache on writes for selected tables (Team, User, Service).

## Changes
- Added Redis caching middleware to Prisma client
- Implemented cache get/set for read operations
- Added cache invalidation for write operations
- Configured cache TTL (5 minutes by default)

## Usage
Set `REDIS_CACHE_ENABLED=true` in environment variables to activate caching