### PR TITLE
feat: Add advanced search settings to nitpick search page

### DIFF
--- a/pages/nitpick/index.module.css
+++ b/pages/nitpick/index.module.css
@@ -387,6 +387,71 @@
   box-shadow: none !important;
 }
 
+/* Advanced search components */
+.searchRow {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.searchInput {
+  flex: 1;
+}
+
+.advancedToggle {
+  padding: 0.75rem;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.advancedToggle:hover {
+  background-color: #e0e0e0;
+}
+
+.advancedSettings {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+  background: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  margin-top: 1rem;
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filterGroup label {
+  font-size: 0.9rem;
+  color: #666;
+  font-weight: 500;
+}
+
+.filterGroup input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.filterGroup input:focus {
+  outline: none;
+  border-color: #0070f3;
+  box-shadow: 0 0 0 2px rgba(0, 112, 243, 0.2);
+}
+
 /* Ensure the spinner overlay covers the whole container */
 .spinnerOverlay {
   @apply fixed inset-0 flex items-center justify-center bg-gray-100 bg-opacity-50 z-50;

--- a/pages/nitpick/search.js
+++ b/pages/nitpick/search.js
@@ -33,6 +33,11 @@ export default function Map3D({ nitpicks: serverNitpicks }) {
   const [hoveredListingId, setHoveredListingId] = useState(null);
   const [hoverTimeout, setHoverTimeout] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [bedrooms, setBedrooms] = useState('');
+  const [bathrooms, setBathrooms] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
   const submitButtonRef = useRef(null);
 
   const currentTeamId = getCookie('currentTeamId');
@@ -89,7 +94,14 @@ export default function Map3D({ nitpicks: serverNitpicks }) {
     e.preventDefault();
     setLoading(true);
     try {
-      const response = await axios.post(`/api/search`, searchTerm);
+      const searchParams = {
+  query: searchTerm,
+  bedrooms: bedrooms,
+  bathrooms: bathrooms,
+  minPrice: minPrice,
+  maxPrice: maxPrice
+};
+const response = await axios.post(`/api/search`, searchParams);
       if (response.data.length === 0) {
         setMapError('No listings found for the specified location.');
         setLoading(false);
@@ -158,21 +170,76 @@ export default function Map3D({ nitpicks: serverNitpicks }) {
       <div className={styles.searchContainer}>
         <header className={styles.searchHeader}>
           <form onSubmit={handleSearch} className={styles.searchForm}>
-            <input
-              type="text"
-              placeholder="Search Your Dream Home..."
-              className={styles.searchInput}
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-            />
-            <button
-              type="submit"
-              className={loading ? `${styles.searchButton} ${styles.loading}` : styles.searchButton}
-              disabled={loading}
-              ref={submitButtonRef}
-            >
-              {loading ? 'Processing...' : 'Search'}
-            </button>
+            <div className={styles.searchRow}>
+              <input
+                type="text"
+                placeholder="Search Your Dream Home..."
+                className={styles.searchInput}
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+              <button
+                type="submit"
+                className={loading ? `${styles.searchButton} ${styles.loading}` : styles.searchButton}
+                disabled={loading}
+                ref={submitButtonRef}
+              >
+                {loading ? 'Processing...' : 'Search'}
+              </button>
+              <button
+                type="button"
+                className={styles.advancedToggle}
+                onClick={() => setShowAdvanced(!showAdvanced)}
+                title="Advanced search settings"
+              >
+                ⚙️
+              </button>
+            </div>
+            
+            {showAdvanced && (
+              <div className={styles.advancedSettings}>
+                <div className={styles.filterGroup}>
+                  <label>Bedrooms</label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={bedrooms}
+                    onChange={(e) => setBedrooms(e.target.value)}
+                    placeholder="Any"
+                  />
+                </div>
+                <div className={styles.filterGroup}>
+                  <label>Bathrooms</label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={bathrooms}
+                    onChange={(e) => setBathrooms(e.target.value)}
+                    placeholder="Any"
+                  />
+                </div>
+                <div className={styles.filterGroup}>
+                  <label>Min Price</label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={minPrice}
+                    onChange={(e) => setMinPrice(e.target.value)}
+                    placeholder="$ Min"
+                  />
+                </div>
+                <div className={styles.filterGroup}>
+                  <label>Max Price</label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={maxPrice}
+                    onChange={(e) => setMaxPrice(e.target.value)}
+                    placeholder="$ Max"
+                  />
+                </div>
+              </div>
+            )}
           </form>
         </header>
 


### PR DESCRIPTION
## Description

- Added expandable advanced search settings panel
- Added filters for bedrooms, bathrooms, and price range
- Updated search API to include advanced filters
- Implemented modern UI with smooth animations

## Testing

1. Click the gear icon next to search button to expand advanced settings
2. Enter filter values and click Search
3. Verify filters are included in API request